### PR TITLE
Add dependency for LlamaSharp

### DIFF
--- a/TGLLM.App/Dockerfile
+++ b/TGLLM.App/Dockerfile
@@ -1,8 +1,9 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
-USER $APP_UID
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends libgomp1
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["TGLLM.App/TGLLM.App.fsproj", "TGLLM.App/"]
@@ -16,6 +17,7 @@ ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "TGLLM.App.fsproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
+USER $APP_UID
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "TGLLM.App.dll"]


### PR DESCRIPTION
This PR fix error if run bot in docker (not found libgomp1 dependency).